### PR TITLE
1.8.22 update

### DIFF
--- a/recipe/0001-Port-patch-from-Toblerity-Fiona-1122.patch
+++ b/recipe/0001-Port-patch-from-Toblerity-Fiona-1122.patch
@@ -5,7 +5,6 @@ Subject: [PATCH] Port patch from Toblerity/Fiona#1122
 
 ---
  fiona/drvsupport.py      | 27 +++++++++++++++++----------
- pytest.ini               |  3 ++-
  tests/conftest.py        | 18 ++++++++++++++++++
  tests/test_datetime.py   |  6 ++++++
  tests/test_drvsupport.py | 13 +++++++++++++
@@ -91,19 +90,6 @@ index fd44f76..1320248 100644
  }
  
  
-diff --git a/pytest.ini b/pytest.ini
-index b561de3..50a3313 100644
---- a/pytest.ini
-+++ b/pytest.ini
-@@ -8,6 +8,7 @@ filterwarnings =
- markers = 
-     iconv: marks tests that require gdal to be compiled with iconv
-     network: marks tests that require a network connection
--    wheel: marks test that only works when installed from wheel
-+    wheel: marks tests that only works when installed from wheel
-+    gdal: marks tests that are only dependent on GDAL functionality (e.g. for drvsupport)
- 
- testpaths = tests
 diff --git a/tests/conftest.py b/tests/conftest.py
 index 05219ff..3da4b89 100644
 --- a/tests/conftest.py

--- a/recipe/0001-Port-patch-from-Toblerity-Fiona-1122.patch
+++ b/recipe/0001-Port-patch-from-Toblerity-Fiona-1122.patch
@@ -1,0 +1,269 @@
+From c0ed73b4ddf362679377d7bc572eaf0b100aa8c7 Mon Sep 17 00:00:00 2001
+From: Klaus Zimmermann <klaus.zimmermann@smhi.se>
+Date: Mon, 5 Dec 2022 13:30:37 +0100
+Subject: [PATCH] Port patch from Toblerity/Fiona#1122
+
+---
+ fiona/drvsupport.py      | 27 +++++++++++++++++----------
+ pytest.ini               |  3 ++-
+ tests/conftest.py        | 18 ++++++++++++++++++
+ tests/test_datetime.py   |  6 ++++++
+ tests/test_drvsupport.py | 13 +++++++++++++
+ 5 files changed, 56 insertions(+), 11 deletions(-)
+
+diff --git a/fiona/drvsupport.py b/fiona/drvsupport.py
+index fd44f76..1320248 100644
+--- a/fiona/drvsupport.py
++++ b/fiona/drvsupport.py
+@@ -40,7 +40,7 @@ supported_drivers = dict([
+     # ESRI FileGDB 	FileGDB 	Yes 	Yes 	No, needs FileGDB API library
+     # multi-layer
+     ("FileGDB", "raw"),
+-    ("OpenFileGDB", "r"),
++    ("OpenFileGDB", "raw"),
+     # ESRI Personal GeoDatabase 	PGeo 	No 	Yes 	No, needs ODBC library
+     # ESRI ArcSDE 	SDE 	No 	Yes 	No, needs ESRI SDE
+     # ESRIJSON 	ESRIJSON 	No 	Yes 	Yes 
+@@ -48,11 +48,11 @@ supported_drivers = dict([
+     # ESRI Shapefile 	ESRI Shapefile 	Yes 	Yes 	Yes
+     ("ESRI Shapefile", "raw"),
+     # FMEObjects Gateway 	FMEObjects Gateway 	No 	Yes 	No, needs FME
+-    ("FlatGeobuf", "rw"),
++    ("FlatGeobuf", "raw"),
+     # GeoJSON 	GeoJSON 	Yes 	Yes 	Yes
+     ("GeoJSON", "raw"),
+     # GeoJSONSeq 	GeoJSON sequences 	Yes 	Yes 	Yes 
+-    ("GeoJSONSeq", "rw"),
++    ("GeoJSONSeq", "raw"),
+     # Géoconcept Export 	Geoconcept 	Yes 	Yes 	Yes
+     # multi-layers
+     #   ("Geoconcept", "raw"),
+@@ -157,12 +157,16 @@ driver_mode_mingdal = {
+     'w': {'GPKG': (1, 11, 0),
+           'PCIDSK': (2, 0, 0),
+           'GeoJSONSeq': (2, 4, 0),
+-          'FlatGeobuf': (3, 1, 3)},
++          'FlatGeobuf': (3, 1, 3),
++          'OpenFileGDB': (3, 6, 0)},
+ 
+     'a': {'GPKG': (1, 11, 0),
+           'PCIDSK': (2, 0, 0),
+           'GeoJSON': (2, 1, 0),
+-          'MapInfo File': (2, 0, 0)}
++          'GeoJSONSeq': (3, 6, 0),
++          'MapInfo File': (2, 0, 0),
++          'FlatGeobuf': (3, 5, 1),
++          'OpenFileGDB': (3, 6, 0)}
+ }
+ 
+ 
+@@ -253,8 +257,9 @@ _driver_field_type_unsupported = {
+         'BNA': None,
+         'DXF': None,
+         'PCIDSK': (2, 1, 0),
+-        'FileGDB': None,
+-        'FlatGeobuf': None
++        'FileGDB': (3, 5, 0),
++        'FlatGeobuf': None,
++        'OpenFileGDB': None
+     },
+     'datetime': {
+         'ESRI Shapefile': None,
+@@ -271,8 +276,9 @@ _driver_field_type_unsupported = {
+         'BNA': None,
+         'DXF': None,
+         'PCIDSK': (2, 1, 0),
+-        'FileGDB': None,
+-        'FlatGeobuf': None
++        'FileGDB': (3, 5, 0),
++        'FlatGeobuf': None,
++        'OpenFileGDB': None
+     }
+ }
+ 
+@@ -331,7 +337,8 @@ def _driver_supports_timezones(driver, field_type):
+ # None: driver never supports timezones, (2, 0, 0): driver supports timezones with GDAL 2.0.0
+ _drivers_not_supporting_milliseconds = {
+     'GPSTrackMaker': None,
+-    'FileGDB': None
++    'FileGDB': None,
++    'OpenFileGDB': None
+ }
+ 
+ 
+diff --git a/pytest.ini b/pytest.ini
+index b561de3..50a3313 100644
+--- a/pytest.ini
++++ b/pytest.ini
+@@ -8,6 +8,7 @@ filterwarnings =
+ markers = 
+     iconv: marks tests that require gdal to be compiled with iconv
+     network: marks tests that require a network connection
+-    wheel: marks test that only works when installed from wheel
++    wheel: marks tests that only works when installed from wheel
++    gdal: marks tests that are only dependent on GDAL functionality (e.g. for drvsupport)
+ 
+ testpaths = tests
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 05219ff..3da4b89 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -32,6 +32,24 @@ driver_extensions = {'DXF': 'dxf',
+                      'FlatGeobuf': 'fgb'}
+ 
+ 
++def pytest_collection_modifyitems(config, items):
++
++    # Fiona contains some tests that depend only on GDALs behavior.
++    # E.g. some test the driver specific access modes maintained in
++    # fiona/drvsupport.py for different GDAL versions.
++    # These tests can fail on exotic architectures (e.g. not returning 
++    # the exact same value)
++    # We explicitly enable these tests on Fiona CI using pytest -m gdal
++    # and hide these tests otherwise.
++    markers_options = config.getoption("-m", "")
++    if "gdal" not in markers_options:
++        skip_gdal = pytest.mark.skip(reason="use '-m gdal' to run GDAL related tests.")
++        for item in items:
++            gdal_marker = item.get_closest_marker("gdal")
++            if gdal_marker is not None and gdal_marker.name == "gdal":
++                item.add_marker(skip_gdal)
++
++
+ def pytest_report_header(config):
+     headers = []
+     # gdal version number
+diff --git a/tests/test_datetime.py b/tests/test_datetime.py
+index 4de8053..d5e4639 100644
+--- a/tests/test_datetime.py
++++ b/tests/test_datetime.py
+@@ -269,6 +269,7 @@ test_cases_datefield, test_cases_datefield_to_str, test_cases_datefield_not_supp
+ 
+ 
+ @pytest.mark.parametrize("driver, field_type", test_cases_datefield)
++@pytest.mark.gdal
+ def test_datefield(tmpdir, driver, field_type):
+     """
+     Test date, time, datetime field types.
+@@ -342,6 +343,7 @@ def test_datefield(tmpdir, driver, field_type):
+ 
+ 
+ @pytest.mark.parametrize("driver, field_type", test_cases_datefield_to_str)
++@pytest.mark.gdal
+ def test_datefield_driver_converts_to_string(tmpdir, driver, field_type):
+     """
+     Test handling of date, time, datetime for drivers that convert these types to string.
+@@ -528,6 +530,7 @@ def test_datefield_driver_converts_to_string(tmpdir, driver, field_type):
+ 
+ @pytest.mark.filterwarnings('ignore:.*driver silently converts *:UserWarning')
+ @pytest.mark.parametrize("driver,field_type", test_cases_datefield + test_cases_datefield_to_str)
++@pytest.mark.gdal
+ def test_datefield_null(tmpdir, driver, field_type):
+     """
+     Test handling of null values for date, time, datetime types for write capable drivers
+@@ -560,6 +563,7 @@ def test_datefield_null(tmpdir, driver, field_type):
+ 
+ 
+ @pytest.mark.parametrize("driver, field_type", test_cases_datefield_not_supported)
++@pytest.mark.gdal
+ def test_datetime_field_unsupported(tmpdir, driver, field_type):
+     """ Test if DriverSupportError is raised for unsupported field_types"""
+     schema = get_schema(driver, field_type)
+@@ -575,6 +579,7 @@ def test_datetime_field_unsupported(tmpdir, driver, field_type):
+ 
+ 
+ @pytest.mark.parametrize("driver, field_type", test_cases_datefield_not_supported)
++@pytest.mark.gdal
+ def test_datetime_field_type_marked_not_supported_is_not_supported(tmpdir, driver, field_type, monkeypatch):
+     """ Test if a date/datetime/time field type marked as not not supported is really not supported
+ 
+@@ -628,6 +633,7 @@ def generate_tostr_testcases():
+ 
+ @pytest.mark.filterwarnings('ignore:.*driver silently converts *:UserWarning')
+ @pytest.mark.parametrize("driver,field_type", test_cases_datefield_to_str)
++@pytest.mark.gdal
+ def test_driver_marked_as_silently_converts_to_str_converts_silently_to_str(tmpdir, driver, field_type, monkeypatch):
+     """ Test if a driver and field_type is marked in fiona.drvsupport.driver_converts_to_str to convert to str really
+       silently converts to str
+diff --git a/tests/test_drvsupport.py b/tests/test_drvsupport.py
+index dad53b6..a1ec328 100644
+--- a/tests/test_drvsupport.py
++++ b/tests/test_drvsupport.py
+@@ -16,6 +16,7 @@ log = logging.getLogger()
+ 
+ 
+ @requires_gdal24
++@pytest.mark.gdal
+ @pytest.mark.parametrize("format", ["GeoJSON", "ESRIJSON", "TopoJSON", "GeoJSONSeq"])
+ def test_geojsonseq(format):
+     """Format is available"""
+@@ -25,6 +26,7 @@ def test_geojsonseq(format):
+ @pytest.mark.parametrize(
+     "driver", [driver for driver, raw in supported_drivers.items() if "w" in raw]
+ )
++@pytest.mark.gdal
+ def test_write_or_driver_error(tmpdir, driver, testdata_generator):
+     """
+     Test if write mode works.
+@@ -73,6 +75,7 @@ def test_write_or_driver_error(tmpdir, driver, testdata_generator):
+ @pytest.mark.parametrize(
+     "driver", [driver for driver in driver_mode_mingdal["w"].keys()]
+ )
++@pytest.mark.gdal
+ def test_write_does_not_work_when_gdal_smaller_mingdal(
+     tmpdir, driver, testdata_generator, monkeypatch
+ ):
+@@ -112,6 +115,7 @@ def test_write_does_not_work_when_gdal_smaller_mingdal(
+ @pytest.mark.parametrize(
+     "driver", [driver for driver, raw in supported_drivers.items() if "a" in raw]
+ )
++@pytest.mark.gdal
+ def test_append_or_driver_error(tmpdir, testdata_generator, driver):
+     """Test if driver supports append mode.
+ 
+@@ -178,6 +182,7 @@ def test_append_or_driver_error(tmpdir, testdata_generator, driver):
+         if driver in supported_drivers
+     ],
+ )
++@pytest.mark.gdal
+ def test_append_does_not_work_when_gdal_smaller_mingdal(
+     tmpdir, driver, testdata_generator, monkeypatch
+ ):
+@@ -190,6 +195,10 @@ def test_append_does_not_work_when_gdal_smaller_mingdal(
+     if driver == "BNA" and GDALVersion.runtime() < GDALVersion(2, 0):
+         pytest.skip("BNA driver segfaults with gdal 1.11")
+ 
++    if driver == "FlatGeobuf" and GDALVersion.runtime() < GDALVersion(3, 5):
++        pytest.skip("FlatGeobuf segfaults with GDAL < 3.5.1")
++
++
+     path = str(tmpdir.join(get_temp_filename(driver)))
+     schema, crs, records1, records2, test_equal, create_kwargs = testdata_generator(
+         driver, range(0, 5), range(5, 10)
+@@ -236,6 +245,7 @@ def test_append_does_not_work_when_gdal_smaller_mingdal(
+ @pytest.mark.parametrize(
+     "driver", [driver for driver, raw in supported_drivers.items() if raw == "r"]
+ )
++@pytest.mark.gdal
+ def test_no_write_driver_cannot_write(tmpdir, driver, testdata_generator, monkeypatch):
+     """Test if read only driver cannot write
+ 
+@@ -271,6 +281,7 @@ def test_no_write_driver_cannot_write(tmpdir, driver, testdata_generator, monkey
+         if "w" in raw and "a" not in raw
+     ],
+ )
++@pytest.mark.gdal
+ def test_no_append_driver_cannot_append(
+     tmpdir, driver, testdata_generator, monkeypatch
+ ):
+@@ -285,6 +296,8 @@ def test_no_append_driver_cannot_append(
+ 
+     if driver == "BNA" and GDALVersion.runtime() < GDALVersion(2, 0):
+         pytest.skip("BNA driver segfaults with gdal 1.11")
++    if driver == "FlatGeobuf" and get_gdal_version_num() == calc_gdal_version_num(3, 5, 0):
++        pytest.skip("FlatGeobuf driver segfaults with gdal 3.5.0")
+ 
+     path = str(tmpdir.join(get_temp_filename(driver)))
+     schema, crs, records1, records2, test_equal, create_kwargs = testdata_generator(
+-- 
+2.35.1

--- a/recipe/0002-add-OpenFileGDB-extension.patch
+++ b/recipe/0002-add-OpenFileGDB-extension.patch
@@ -1,0 +1,11 @@
+diff -ruN -x __pycache__ -x obj -x '*~' -x tags -x TAGS Fiona-1.8.22.drvsupport/tests/conftest.py Fiona-1.8.22.OpenFileGDB/tests/conftest.py
+--- Fiona-1.8.22.drvsupport/tests/conftest.py	2022-12-09 12:53:22.695413628 +0100
++++ Fiona-1.8.22.OpenFileGDB/tests/conftest.py	2022-12-09 13:13:02.617323974 +0100
+@@ -18,6 +18,7 @@
+                      'CSV': 'csv',
+                      'ESRI Shapefile': 'shp',
+                      'FileGDB': 'gdb',
++                     'OpenFileGDB': 'gdb',
+                      'GML': 'gml',
+                      'GPX': 'gpx',
+                      'GPSTrackMaker': 'gtm',

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,5 +5,5 @@ set GDAL_VERSION=%%F
 if errorlevel 1 exit 1
 echo "set GDAL_VERSION=%GDAL_VERSION%"
 
-%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal_i -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,6 @@ set GDAL_VERSION=%%F
 if errorlevel 1 exit 1
 echo "set GDAL_VERSION=%GDAL_VERSION%"
 
-%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal_i -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
-if errorlevel 1 %PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+:: Replace "-lgdal" with "-lgdal_i" if building with libgdal version greater than 3.0.2
+%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,6 @@ set GDAL_VERSION=%%F
 if errorlevel 1 exit 1
 echo "set GDAL_VERSION=%GDAL_VERSION%"
 
-:: Replace "-lgdal" with "-lgdal_i" if building with libgdal version greater than 3.0.2
-%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+:: Replace "-lgdal_i" with "-lgdal" if building with libgdal version greater than 3.0.2
+%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal_i -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,5 +5,5 @@ set GDAL_VERSION=%%F
 if errorlevel 1 exit 1
 echo "set GDAL_VERSION=%GDAL_VERSION%"
 
-%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal_i -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,5 +5,6 @@ set GDAL_VERSION=%%F
 if errorlevel 1 exit 1
 echo "set GDAL_VERSION=%GDAL_VERSION%"
 
-%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal_i -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+if errorlevel 1 %PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,9 @@
-:: There is no `gdal-config` on Windows so we need to hardcode gdal's version.
-set GDAL_VERSION=3.0.2
+:: There is no `gdal-config` on Windows so we need figure it out from gdalinfo
+for /F "USEBACKQ tokens=2 delims=, " %%F in (`gdalinfo --version`) do (
+set GDAL_VERSION=%%F
+)
+if errorlevel 1 exit 1
+echo "set GDAL_VERSION=%GDAL_VERSION%"
 
-"%PYTHON%" -m pip install --no-deps --ignore-installed . ^
-                          --global-option=build_ext ^
-                          --global-option="-I%LIBRARY_INC%" ^
-                          --global-option="-L%LIBRARY_LIB%" ^
-                          --global-option="-lgdal_i"
+%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgdal -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   host:
     - python
     - pip
-    - cython >=0.29.29
+    - cython 0.29.32
     - numpy
     - libgdal 3.0.2
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ about:
   home: http://github.com/Toblerity/Fiona
   license: BSD-3-Clause
   license_file: LICENSE.txt
-  summary: 'Fiona reads and writes spatial data files'
+  summary: Fiona reads and writes spatial data files
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ build:
   number: 0
   skip: True  # [win and vc<14]
   skip: True  # [py<36]
+  # There is no libgdal for ppc
+  skip: True  # [linux and ppc64le]
   entry_points:
     - fio = fiona.fio.main:main_group
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - six >=1.7
     - munch
     - shapely
-    - enum34  # [py<34]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   skip: True  # [win and vc<14]
+  skip: True  # [py<36]
   entry_points:
     - fio = fiona.fio.main:main_group
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ build:
   number: 0
   skip: True  # [win and vc<14]
   skip: True  # [py<36]
-  # There is no libgdal for ppc
-  skip: True  # [linux and ppc64le]
+  # There is no libgdal for s390x
+  skip: True  # [linux and s390x]
   entry_points:
     - fio = fiona.fio.main:main_group
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   url: https://pypi.io/packages/source/F/Fiona/Fiona-{{ version }}.tar.gz
   sha256: a82a99ce9b3e7825740157c45c9fb2259d4e92f0a886aaac25f0db40ffe1eea3
-  patches:
+  patches:  # [win]
     # Both patches should be unnecessary for fiona v1.9
     - 0001-Port-patch-from-Toblerity-Fiona-1122.patch  # [win]
     - 0002-add-OpenFileGDB-extension.patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ test:
     - boto3 >=1.2.4
     - packaging
     #- pytest-catchlog
+    - pytz
   files:
     - test_data
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,9 +53,11 @@ test:
     - packaging
     #- pytest-catchlog
     - pytz
+    - pip
   files:
     - test_data
   commands:
+    - pip check
     - fio --help
     - fio ls test_data/test.shp
     - fio info test_data/test.shp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,10 +63,12 @@ test:
     - fio info test_data/test.shp
 
 about:
-  home: http://github.com/Toblerity/Fiona
+  home: https://github.com/Toblerity/Fiona
   license: BSD-3-Clause
   license_file: LICENSE.txt
+  license_family: BSD
   summary: Fiona reads and writes spatial data files
+  doc_url: https://fiona.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,8 @@ source:
   url: https://pypi.io/packages/source/F/Fiona/Fiona-{{ version }}.tar.gz
   sha256: a82a99ce9b3e7825740157c45c9fb2259d4e92f0a886aaac25f0db40ffe1eea3
   patches:
-    - 0001-Port-patch-from-Toblerity-Fiona-1122.patch
-    - 0002-add-OpenFileGDB-extension.patch
+    - 0001-Port-patch-from-Toblerity-Fiona-1122.patch  # [win]
+    - 0002-add-OpenFileGDB-extension.patch  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@ source:
   url: https://pypi.io/packages/source/F/Fiona/Fiona-{{ version }}.tar.gz
   sha256: a82a99ce9b3e7825740157c45c9fb2259d4e92f0a886aaac25f0db40ffe1eea3
   patches:
+    # Both patches should be unnecessary for fiona v1.9
     - 0001-Port-patch-from-Toblerity-Fiona-1122.patch  # [win]
     - 0002-add-OpenFileGDB-extension.patch  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,9 @@ package:
 source:
   url: https://pypi.io/packages/source/F/Fiona/Fiona-{{ version }}.tar.gz
   sha256: a82a99ce9b3e7825740157c45c9fb2259d4e92f0a886aaac25f0db40ffe1eea3
+  patches:
+    - 0001-Port-patch-from-Toblerity-Fiona-1122.patch
+    - 0002-add-OpenFileGDB-extension.patch
 
 build:
   number: 0
@@ -19,6 +22,7 @@ build:
 
 requirements:
   build:
+    - m2-patch  # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - certifi  # [py<=37]
   run:
     - python
+    - setuptools
     - gdal
     - {{ pin_compatible('numpy') }}
     - attrs >=17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,6 @@ test:
     - boto3 >=1.2.4
     - packaging
     #- pytest-catchlog
-    - mock  # [py2k]
   files:
     - test_data
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,18 +28,21 @@ requirements:
     - numpy
     - libgdal
     - wheel
+    - setuptools
+    - certifi  # [py<=37]
   run:
     - python
-    - setuptools
     - gdal
     - {{ pin_compatible('numpy') }}
     - attrs >=17
-    - click >=4.0,<8
+    - click >=4.0
     - cligj >=0.5
     - click-plugins >=1.0
     - six >=1.7
     - munch
-    - shapely
+    - shapely  # only option calc we include by default
+    - certifi  # [py<=37]
+
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,11 +65,6 @@ test:
     - pip
   files:
     - test_data
-#  commands:
-#    - pip check
-#    - fio --help
-#    - fio ls test_data/test.shp
-#    - fio info test_data/test.shp
 
 about:
   home: https://github.com/Toblerity/Fiona

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - pip
     - cython >=0.29.29
     - numpy
-    - libgdal
+    - libgdal 3.0.2
     - wheel
     - setuptools
     - certifi  # [py<=37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,6 @@ source:
 build:
   number: 0
   skip: True  # [win and vc<14]
-  # There is no libgdal for ppc or win32
-  skip: True  # [win32] 
-  skip: True  # [linux and ppc64le]
   entry_points:
     - fio = fiona.fio.main:main_group
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   host:
     - python
     - pip
-    - cython >=0.28.3
+    - cython >=0.29.29
     - numpy
     - libgdal
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,11 +64,11 @@ test:
     - pip
   files:
     - test_data
-  commands:
-    - pip check
-    - fio --help
-    - fio ls test_data/test.shp
-    - fio info test_data/test.shp
+#  commands:
+#    - pip check
+#    - fio --help
+#    - fio ls test_data/test.shp
+#    - fio info test_data/test.shp
 
 about:
   home: https://github.com/Toblerity/Fiona

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - pip
     - cython >=0.29.29
     - numpy
-    - libgdal
     - gdal
     - wheel
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.13.post1" %}
+{% set version = "1.8.22" %}
 
 package:
   name: fiona
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/F/Fiona/Fiona-{{ version }}.tar.gz
-  sha256: 1a432bf9fd56f089256c010da009c90d4a795c531a848132c965052185336600
+  sha256: a82a99ce9b3e7825740157c45c9fb2259d4e92f0a886aaac25f0db40ffe1eea3
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - pip
     - cython >=0.29.29
     - numpy
-    - gdal
+    - libgdal
     - wheel
     - setuptools
     - certifi  # [py<=37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - cython >=0.29.29
     - numpy
     - libgdal
+    - wheel
   run:
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - cython >=0.29.29
     - numpy
     - libgdal
+    - gdal
     - wheel
     - setuptools
     - certifi  # [py<=37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,14 @@ about:
   license_file: LICENSE.txt
   license_family: BSD
   summary: Fiona reads and writes spatial data files
+  description: |
+    Fiona reads and writes geographic data files and
+    thereby helps Python programmers integrate geographic
+    information systems with other computer systems.
+    Fiona contains extension modules that link the
+    Geospatial Data Abstraction Library (GDAL).
   doc_url: https://fiona.readthedocs.io/en/latest/
+  dev_url: https://github.com/Toblerity/Fiona
 
 extra:
   recipe-maintainers:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -5,3 +5,6 @@ xcopy test_data\coutwildrnp.json tests\data /s /e /y || exit 1
 
 %PYTHON% -m pytest -s -rxs -v -m "not wheel" -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction or test_no_append_driver_cannot_append[PCIDSK])" tests
 %PYTHON% -m pip check
+fio --help
+fio ls test_data/test.shp
+fio info test_data/test.shp

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -3,5 +3,4 @@ xcopy test_data\coutwildrnp.zip tests\data /s /e /y || exit 1
 xcopy test_data\coutwildrnp.tar tests\data /s /e /y || exit 1
 xcopy test_data\coutwildrnp.json tests\data /s /e /y || exit 1
 
-:: The tests are finishing but it hangs at the end :-/
-REM pytest -s -rxs -v -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction)" tests
+%PYTHON% -m pytest -s -rxs -v -m "not wheel" -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction or test_no_append_driver_cannot_append[PCIDSK])" tests

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -4,3 +4,4 @@ xcopy test_data\coutwildrnp.tar tests\data /s /e /y || exit 1
 xcopy test_data\coutwildrnp.json tests\data /s /e /y || exit 1
 
 %PYTHON% -m pytest -s -rxs -v -m "not wheel" -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction or test_no_append_driver_cannot_append[PCIDSK])" tests
+%PYTHON% -m pip check

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -9,6 +9,9 @@ pushd /tmp
 $PYTHON -m pytest -s -rxs -v -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction or test_encoding_option_warning)"  -m "not wheel" tests
 popd
 $PYTHON -m pip check
+fio --help
+fio ls test_data/test.shp
+fio info test_data/test.shp
 # I believe it is safe to ignore the failures in tests/test_listing.py
 #     def test_directory_trailing_slash(data_dir):
 # >       assert fiona.listlayers(data_dir) == ['coutwildrnp', 'gre']

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -8,7 +8,7 @@ pushd /tmp
 
 $PYTHON -m pytest -s -rxs -v -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction or test_encoding_option_warning)"  -m "not wheel" tests
 popd
-
+$PYTHON -m pip check
 # I believe it is safe to ignore the failures in tests/test_listing.py
 #     def test_directory_trailing_slash(data_dir):
 # >       assert fiona.listlayers(data_dir) == ['coutwildrnp', 'gre']


### PR DESCRIPTION
### Links:
- [Upstream repository](https://github.com/Toblerity/Fiona) 
- [Fiona changelog](https://github.com/Toblerity/Fiona/blob/1.8.22/CHANGES.txt)
- [Jira issue](https://anaconda.atlassian.net/browse/PKG-929)

Update required for pending updates to `geoviews` and `geopandas`

### Changes:
- Added two patches from conda-forge to enable building on Windows.
  - Both patches will be obsolete upon release of `fiona 1.9`
  - [0001-Port-patch-from-Toblerity-Fiona-1122.patch](https://github.com/conda-forge/fiona-feedstock/blob/main/recipe/0001-Port-patch-from-Toblerity-Fiona-1122.patch)
    - Removed broken portion of patch modifying pytest.ini
    - Backport of `fiona 1.9` changes.
  - [0002-add-OpenFileGDB-extension.patch](https://github.com/conda-forge/fiona-feedstock/blob/main/recipe/0002-add-OpenFileGDB-extension.patch)
    - Metadata handling is being overhauled in `fiona 1.9` which will make this patch unnecessary.
- Pinned `libgdal 3.0.2` due to `-lgdal_i` flag being changed to `-lgdal` in later versions, which will require changes to bld.bat.
- Re-enabled tests on Windows.
  - Disabled `test_no_append_driver_cannot_append[PCIDSK]` as it was causing tests to hang.
- Added pip check to run_tests.sh and run_tests.bat.
- Added `certifi` for python 3.7.
- Pinned specific version of `cython` per [recipe standards](https://github.com/anaconda-distribution/perseverance-skills/blob/main/sections/Reference/Recipe_standards.md#the-requirements-section) and [fiona build requirements.](https://github.com/Toblerity/Fiona/blob/bae44db5845955870a850fb53f67c9a4ab4c55d4/CHANGES.txt#L9-L10)