### PR TITLE
Rebuild for geopandas

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3a3725e94840a387fef48726d60db6a6791563f366939d22378a4661f8941be7
 
 build:
-  number: 0
+  number: 1
   # There is no libgdal for s390x
   skip: True  # [py<37 or s390x]
   entry_points:


### PR DESCRIPTION
Rebuilding Python 3.12 and geopandas

Log:
- Adding abs.yaml
- Bumping build number